### PR TITLE
small changes for compatibility with AT 1.6.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/ariatemplates/at-hashspace-bridge.git"
   },
   "devDependencies": {
-    "ariatemplates" : "1.6.0-beta.4",
+    "ariatemplates" : "1.6.4",
     "attester" : "1.4.1",
     "hashspace" : "git+https://github.com/ariatemplates/hashspace.git#master",
     "noder-js" : "1.3.0",
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "start": "grunt",
-    "install": "cd node_modules/hashspace && npm install --development",
+    "install": "cd node_modules/hashspace && npm install --development && grunt package",
     "test": "node node_modules/attester/bin/attester.js attester.yml --shutdown-on-campaign-end false --phantomjs-instances 1 "
   }
 }

--- a/public_html/index.html
+++ b/public_html/index.html
@@ -6,7 +6,7 @@
     <!-- To serve non-minified files, it's also needed to change gruntfile's path to /aria -->
     <!-- script type="text/javascript" src="./aria/bootstrap.js" /script -->
     <!-- script type="text/javascript" src="./aria/css/atskin.js" /script -->
-    <script type="text/javascript" src="./aria/ariatemplates-1.6.0-beta.3.js">
+    <script type="text/javascript" src="./aria/ariatemplates-1.6.4.js">
     {
         packaging : {
           preprocessors: [{
@@ -22,7 +22,7 @@
         }
     }
     </script>
-    <script type="text/javascript" src="./aria/css/atskin-1.6.0-beta.3.js"></script>
+    <script type="text/javascript" src="./aria/css/atskin-1.6.4.js"></script>
     <script type="text/javascript" src="./hashspace/hashspace-noder.min.js"></script>
     <script type="text/javascript" src="./hashspace/hashspace-noder-compiler.min.js"></script>
   </head>
@@ -30,7 +30,7 @@
     <div id="outputHSP"></div>
     <div id="outputAT"></div>
 
-    <script type="noder">
+    <script type="application/x-noder">
         var hello = require("templates/hsp/hello.hsp").hello;
         hello().render("outputHSP");
 


### PR DESCRIPTION
References to `1.6.0-beta.4` are changed in `1.6.4`, the `grunt package` command is necessary to generate the module peg.js and `<script type="noder">` are converted in the new `<script type="application/x-noder">`
